### PR TITLE
Added the necessary 2nd stop codon for the vaccine

### DIFF
--- a/side-by-side.csv
+++ b/side-by-side.csv
@@ -1273,3 +1273,4 @@ abspos,codonOrig,codonVaccine
 3813,TAC,TAC
 3816,ACA,ACA
 3819,TAA,TGA
+3822,,TGA


### PR DESCRIPTION
In https://github.com/berthubert/bnt162b2/blob/master/side-by-side.csv at line 1275 there is only one TGA/UGA for the vaccine, but in https://berthub.eu/articles/posts/reverse-engineering-source-code-of-the-biontech-pfizer-vaccine/ at section "The end of the protein, next steps" you wrote that the vaccine uses 2 stop of these stop codons.

Therefore I fixed it by adding the second stop codon at the end of the csv file.